### PR TITLE
Make the zoom plugin height based

### DIFF
--- a/config_template.ini
+++ b/config_template.ini
@@ -177,7 +177,7 @@ size = 14
 #   hold = set to first value when pressed, to second when released
 #   toggle = cycle through values on each press
 map visible hold yes no = Right Ctrl
-zoom level toggle -1 3000 = Keypad 0
+zoom level toggle -1 1500 = Keypad 0
 misc centered toggle 1 2 = Keypad 5
 playerlist visible hold yes no = V
 # show information about triggered keybinds in top left corner, useful for debugging

--- a/plugins/zoom.py
+++ b/plugins/zoom.py
@@ -53,15 +53,14 @@ class Plugin(PluginBase):
         cw = self.refs.canvasW_
         ch = self.refs.canvasH_
 
-        cscale = cw[0] / self.refs.windowW
+        cscale = ch[0] / self.refs.windowH
         ctime = time.perf_counter()
 
         if not self.config.active:
             self.start = self.target = 1
             nscale = 1
         else:
-            twidth = self.config.level
-            targ = twidth / self.refs.windowW
+            targ = self.config.level / self.refs.windowH
 
             if targ <= 0:
                 targ = 1
@@ -86,6 +85,7 @@ class Plugin(PluginBase):
 
         tw = round(nscale * self.refs.windowW)
         th = round(nscale * self.refs.windowH)
+        #logging.info(str(tw) + 'x' + str(th))
 
         cw[0] = self.refs.overrideW = tw
         ch[0] = self.refs.overrideH = th


### PR DESCRIPTION
This is a much more convenient way of doing things. If you switch to a wider monitor on the current system, your resolution gets ruined. On a height based system the extra width of your monitor gives you extra width in your view of the game - much more intuitive. 