### PR TITLE
Fix mipmap generation for paths with dots

### DIFF
--- a/genmipmaps.py
+++ b/genmipmaps.py
@@ -64,7 +64,7 @@ def loadSheets(sheetnames):
     sheets = {}
     for name in sheetnames:
         b = io.BytesIO(readFile(name))
-        sheets[int(name.split('.')[1])] = Image.open(b)
+        sheets[int(os.path.basename(name).split('.')[1])] = Image.open(b)
     return sheets
 
 


### PR DESCRIPTION
Full paths can contain dots in parent directories (e.g.
“/home/foo/.steam/”), so it is important to work with basenames only.