### PR TITLE
Noise plugin: ignore_own_faction option

### DIFF
--- a/config_template.ini
+++ b/config_template.ini
@@ -164,6 +164,8 @@ hide_effects = no
 replace_shake = no
 # hide chat
 hide_chat = no
+# ignore faction members when hiding shells/objects/names/health
+ignore_own_faction = no
 
 [plugin_playerlist]
 visible = no


### PR DESCRIPTION
Adds an to option skip hiding shells/objects/health/names/faction names if the other player is in the same faction as the current player.